### PR TITLE
`plot_celltype_associations`: Fix adding full method to results

### DIFF
--- a/R/plot_celltype_associations.r
+++ b/R/plot_celltype_associations.r
@@ -90,9 +90,9 @@ plot_celltype_associations <- function(ctAssocs,
     }
 
     # Generate the plots (for each annotation level seperately)
-    theme_set(ggplot2::theme_bw())
+    ggplot2::theme_set(ggplot2::theme_bw())
     figures <- list()
-    for (annotLevel in seq_len(sum(names(ctAssocs) == "") )) {
+    for (annotLevel in seq_len(length(grep("^level.", names(ctAssocs))))) {
         # SET: NEW COLUMN COMBINING METHODS or ENRICHMENT TYPES
         ctAssocs[[annotLevel]]$results$FullMethod <- 
             sprintf("%s %s", 


### PR DESCRIPTION
Hey Brian,

This sum will always retrieve 0, as far as I am aware. I think what you wanted to do is what I just added?

Also, note that MAGMA.Celltyping does not load ggplot2 into the workspace. Probably the user should do this!! ( my bad)
But maybe it is safer to do ggplot2::theme_set

