### PR TITLE
Fix adding full method to results

### DIFF
--- a/R/plot_celltype_associations.r
+++ b/R/plot_celltype_associations.r
@@ -90,9 +90,9 @@ plot_celltype_associations <- function(ctAssocs,
     }
 
     # Generate the plots (for each annotation level seperately)
-    theme_set(ggplot2::theme_bw())
+    ggplot2::theme_set(ggplot2::theme_bw())
     figures <- list()
-    for (annotLevel in seq_len(sum(names(ctAssocs) == "") )) {
+    for (annotLevel in seq_len(length(grep("^level.", names(ctAssocs))))) {
         # SET: NEW COLUMN COMBINING METHODS or ENRICHMENT TYPES
         ctAssocs[[annotLevel]]$results$FullMethod <- 
             sprintf("%s %s", 


### PR DESCRIPTION
I found the reason of #131

Basically, **gh::gh_token()** is not optional but a requirement for **piggyback::pb_download(**) to successfully download the data.

I also found that when **piggyback::pb_download()** failed, a corrupted rds object was saved in cache.
That means in future downloads **piggyback::pb_download()** would not download as the corrupted file is found.
Because the download is very fast, I set **overwrite = TRUE**

Realated to this, I decided to to remove the if statement checking if hte tmp file exists.


In addition, please note that **gh::gh_token()** makes use of gitcreds::gitcreds_get() to retireve the githb_pat -> https://gh.r-lib.org/reference/gh_token.html
I tried to find there in the DockerFile you install the R deps but I was not lucky.
A modification in the Docker image must be done so that **gitcreds** R package is installed.




