### PR TITLE
Fix get_data gh

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -7,31 +7,38 @@
 get_data <- function(fname,
                      repo = "neurogenomics/MAGMA_Celltyping",
                      storage_dir = tools::R_user_dir(
-                         package = "MAGMA.Celltyping",
-                         which = "cache"
+                       package = "MAGMA.Celltyping",
+                       which = "cache"
                      ),
-                     overwrite = FALSE,
+                     overwrite = TRUE,
                      check = FALSE
                      ){
-    tmp <- fix_path(file.path(storage_dir, fname))
-    if (!file.exists(tmp)) {
-        requireNamespace("piggyback")
-        requireNamespace("gh")
-        Sys.setenv("piggyback_cache_duration" = 10)
-        dir.create(storage_dir, showWarnings = FALSE, recursive = TRUE) 
-        .token <- gh::gh_token()
-        if(as.character(.token)=="") .token <- NULL
-        piggyback::pb_download(
-            file = fname,
-            dest = storage_dir,
-            repo = repo,
-            overwrite = overwrite,
-            .token = .token
-        )
+  tmp <- fix_path(file.path(storage_dir, fname))
+  requireNamespace("piggyback")
+  requireNamespace("gh")
+  Sys.setenv("piggyback_cache_duration" = 10)
+  dir.create(storage_dir, showWarnings = FALSE, recursive = TRUE)
+  .token <- gh::gh_token()
+  if(as.character(.token)=="")  {
+    message(paste0("Personal access token is missing and it is required to download ",
+                   names(fname), "\n"))
+    message("Please, configure git with R and try again \n")
+    stop("Personal access token missing missing")
+    } else {
+      piggyback::pb_download(
+        file = fname,
+        dest = storage_dir,
+        repo = repo,
+        overwrite = overwrite,
+        .token = .token
+      )
     }
-    #### Check that download didn't fail due to bad credentials #####
-    if(isTRUE(check)){
-        get_data_check(tmp = tmp)    
+
+  #### Check that download didn't fail due to bad credentials #####
+  if(isTRUE(check)){
+    get_data_check(tmp = tmp)
     }
-    return(tmp)
+  return(tmp)
 }
+
+


### PR DESCRIPTION
I found the reason of #131

Basically, **gh::gh_token()** is not optional but a requirement for **piggyback::pb_download()** to successfully download the data.

I also found that when **piggyback::pb_download()** failed, a corrupted rds object was saved in cache.
That means in future downloads **piggyback::pb_download()** would not download as the corrupted file is found.
Because the download is very fast, I set _overwrite = TRUE_

Realated to this, I decided to to remove the if statement checking if hte tmp file exists.

In addition, please note that **gh::gh_token()** makes use of **gitcreds::gitcreds_get()** to retireve the githb_pat -> https://gh.r-lib.org/reference/gh_token.html
I tried to find there in the DockerFile you install the R deps but I was not lucky.
A modification in the Docker image must be done so that **gitcreds** R package is installed.


